### PR TITLE
fix: truncated title when using KDE Breeze style

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -85,7 +85,7 @@
         </property>
         <property name="font">
          <font>
-          <pointsize>9</pointsize>
+          <pointsize>11</pointsize>
          </font>
         </property>
         <property name="title">


### PR DESCRIPTION
Before:

![Screenshot_20241223_175639](https://github.com/user-attachments/assets/269bf4c8-3847-4f4d-b23a-d7f997b6b82e)

After: 

![Screenshot_20241223_175722](https://github.com/user-attachments/assets/13d49f15-65c1-4c48-ad76-d8d40483054f)
