### PR TITLE
fix: build failure on Linux

### DIFF
--- a/src/preferencesmanager.cpp
+++ b/src/preferencesmanager.cpp
@@ -45,7 +45,7 @@ bool PreferencesManager::loadPreferences()
 #ifdef _WIN32
     QFile file(QString::fromStdWString(m_configFilePath.wstring()));
 #else
-    QFile file(QString::fromStdWString(m_configFilePath.string()));
+    QFile file(QString::fromStdString(m_configFilePath.string()));
 #endif
     if (!file.open(QIODevice::ReadOnly)) {
         video2x::logger()->warn("Failed to open configuration file for reading.");
@@ -149,7 +149,7 @@ bool PreferencesManager::savePreferences()
 #ifdef _WIN32
     QFile file(QString::fromStdWString(m_configFilePath.wstring()));
 #else
-    QFile file(QString::fromStdWString(m_configFilePath.string()));
+    QFile file(QString::fromStdString(m_configFilePath.string()));
 #endif
     if (!file.open(QIODevice::WriteOnly)) {
         video2x::logger()->warn("Failed to open configuration file for writing.");


### PR DESCRIPTION
```
/build/video2x-qt6-git/src/video2x-qt6/src/preferencesmanager.cpp:48:63: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘const std::wstring&’ {aka ‘const std::__cxx11::basic_string<wchar_t>&’}
   48 |     QFile file(QString::fromStdWString(m_configFilePath.string()));
      |                                        ~~~~~~~~~~~~~~~~~~~~~~~^~
      |                                                               |
      |                                                               std::string {aka std::__cxx11::basic_string<char>}
In file included from /usr/include/qt6/QtCore/QString:1,
                 from /build/video2x-qt6-git/src/video2x-qt6/src/preferencesmanager.h:6,
                 from /build/video2x-qt6-git/src/video2x-qt6/src/preferencesmanager.cpp:1:
/usr/include/qt6/QtCore/qstring.h:1465:53: note:   initializing argument 1 of ‘static QString QString::fromStdWString(const std::wstring&)’
 1465 | QString QString::fromStdWString(const std::wstring &s)
      |                                 ~~~~~~~~~~~~~~~~~~~~^
/build/video2x-qt6-git/src/video2x-qt6/src/preferencesmanager.cpp: In member function ‘bool PreferencesManager::savePreferences()’:
/build/video2x-qt6-git/src/video2x-qt6/src/preferencesmanager.cpp:152:63: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘const std::wstring&’ {aka ‘const std::__cxx11::basic_string<wchar_t>&’}
  152 |     QFile file(QString::fromStdWString(m_configFilePath.string()));
      |                                        ~~~~~~~~~~~~~~~~~~~~~~~^~
      |                                                               |
      |                                                               std::string {aka std::__cxx11::basic_string<char>}
/usr/include/qt6/QtCore/qstring.h:1465:53: note:   initializing argument 1 of ‘static QString QString::fromStdWString(const std::wstring&)’
 1465 | QString QString::fromStdWString(const std::wstring &s)
      |                                 ~~~~~~~~~~~~~~~~~~~~^
make[2]: *** [CMakeFiles/video2x-qt6.dir/build.make:210: CMakeFiles/video2x-qt6.dir/src/preferencesmanager.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:96: CMakeFiles/video2x-qt6.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```