### PR TITLE
Add native Apple Silicon (macOS) build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
         add_link_options(/LTCG /OPT:REF /OPT:ICF)
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         add_compile_options(-O3 -ffunction-sections -fdata-sections)
-        add_link_options(-Wl,-s -flto -Wl,--gc-sections)
+        if(APPLE)
+            add_link_options(-flto -Wl,-dead_strip)
+        else()
+            add_link_options(-Wl,-s -flto -Wl,--gc-sections)
+        endif()
     endif()
 endif()
 
@@ -36,7 +40,11 @@ if(VIDEO2X_ENABLE_NATIVE)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         add_compile_options(/arch:NATIVE)
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-        add_compile_options(-march=native)
+        if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64")
+            add_compile_options(-march=native)
+        elseif(NOT APPLE)
+            add_compile_options(-mcpu=native)
+        endif()
     endif()
 elseif(VIDEO2X_ENABLE_X86_64_V4)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
@@ -55,6 +63,7 @@ endif()
 # Define lists to store include directories and libraries
 set(VIDEO2X_QT6_INCLUDE_DIRS)
 set(VIDEO2X_QT6_LIBS)
+set(VIDEO2X_QT6_LIBDIRS)
 
 # Find the required Qt6 components
 find_package(Qt6 REQUIRED COMPONENTS Core Widgets Svg Network LinguistTools)
@@ -64,6 +73,8 @@ list(APPEND VIDEO2X_QT6_LIBS Qt6::Core Qt6::Widgets Qt6::Svg Qt6::Network)
 # Power management dependencies
 if(WIN32)
     list(APPEND VIDEO2X_QT6_LIBS PowrProf.lib)
+elseif(APPLE)
+    # macOS has no logind/DBus; power actions are compiled as no-ops.
 else()
     list(APPEND VIDEO2X_QT6_LIBS Qt6::DBus)
 endif()
@@ -91,6 +102,7 @@ else()
         pkg_check_modules(${PKG} REQUIRED ${PKG})
         list(APPEND VIDEO2X_QT6_INCLUDE_DIRS ${${PKG}_INCLUDE_DIRS})
         list(APPEND VIDEO2X_QT6_LIBS ${${PKG}_LIBRARIES})
+        list(APPEND VIDEO2X_QT6_LIBDIRS ${${PKG}_LIBRARY_DIRS})
     endforeach()
 endif()
 
@@ -196,13 +208,19 @@ target_include_directories(video2x-qt6 PRIVATE
     ${spdlog_INCLUDE_DIRS}
     ${VIDEO2X_QT6_INCLUDE_DIRS}
     ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_SOURCE_DIR}/third_party/video2x/include
 )
 
 if(NOT USE_EXTERNAL_VIDEO2X AND NOT USE_SHARED_VIDEO2X)
+    # Only the build-from-submodule path needs the submodule headers; an
+    # external/prebuilt libvideo2x provides its own (avoids stale headers).
+    target_include_directories(video2x-qt6 PRIVATE
+        ${CMAKE_SOURCE_DIR}/third_party/video2x/include
+    )
     add_dependencies(video2x-qt6 Video2X)
     if(WIN32)
         set(LIBVIDEO2X_LIB ${CMAKE_BINARY_DIR}/video2x-install/libvideo2x.lib)
+    elseif(APPLE)
+        set(LIBVIDEO2X_LIB ${CMAKE_BINARY_DIR}/video2x-install/libvideo2x.dylib)
     else()
         set(LIBVIDEO2X_LIB ${CMAKE_BINARY_DIR}/video2x-install/libvideo2x.so)
     endif()
@@ -210,6 +228,7 @@ if(NOT USE_EXTERNAL_VIDEO2X AND NOT USE_SHARED_VIDEO2X)
 endif()
 
 target_link_libraries(video2x-qt6 PRIVATE ${VIDEO2X_QT6_LIBS})
+target_link_directories(video2x-qt6 PRIVATE ${VIDEO2X_QT6_LIBDIRS})
 
 include(GNUInstallDirs)
 

--- a/src/taskconfigdialog.cpp
+++ b/src/taskconfigdialog.cpp
@@ -475,7 +475,10 @@ std::optional<TaskConfig> TaskConfigDialog::getTaskConfig()
 
     // EncoderConfig
     taskConfig.outputSuffix = ui->suffixLineEdit->text();
-    taskConfig.encCfg.copy_streams = ui->copyStreamsCheckBox->isChecked();
+    // libvideo2x split copy_streams into separate audio/subtitle flags;
+    // drive both from the single "copy streams" checkbox.
+    taskConfig.encCfg.copy_audio_streams = ui->copyStreamsCheckBox->isChecked();
+    taskConfig.encCfg.copy_subtitle_streams = ui->copyStreamsCheckBox->isChecked();
 
     // Rate control and compression
     taskConfig.encCfg.bit_rate = ui->bitRateSpinBox->value();
@@ -681,7 +684,7 @@ void TaskConfigDialog::setTaskConfig(const TaskConfig &taskConfig)
     ui->suffixLineEdit->setText(taskConfig.outputSuffix);
 
     // copy_streams
-    ui->copyStreamsCheckBox->setChecked(taskConfig.encCfg.copy_streams);
+    ui->copyStreamsCheckBox->setChecked(taskConfig.encCfg.copy_audio_streams);
 
     // frameRateMultiplier (only relevant if Interpolate)
     if (procMode == video2x::processors::ProcessingMode::Interpolate) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -9,6 +9,9 @@
 #include <Windows.h>
 #include <powrprof.h>
 // #pragma comment(lib, "PowrProf.lib")
+#elif defined(__APPLE__)
+// macOS has no logind/DBus system bus; the power-management actions below
+// are compiled as no-ops.
 #else
 #include <QDBusInterface>
 #include <QDBusReply>
@@ -76,6 +79,8 @@ void systemShutdown()
     } else {
         video2x::logger()->info("System shutdown initiated successfully.");
     }
+#elif defined(__APPLE__)
+    video2x::logger()->warn("Automatic system shutdown is not supported on macOS; skipping.");
 #else
     QDBusInterface interface("org.freedesktop.login1",
                              "/org/freedesktop/login1",
@@ -108,6 +113,8 @@ void systemSleep()
     } else {
         video2x::logger()->info("System sleep initiated successfully.");
     }
+#elif defined(__APPLE__)
+    video2x::logger()->warn("Automatic system sleep is not supported on macOS; skipping.");
 #else
     QDBusInterface interface("org.freedesktop.login1",
                              "/org/freedesktop/login1",
@@ -139,6 +146,8 @@ void systemHibernate()
     } else {
         video2x::logger()->info("System hibernation initiated successfully.");
     }
+#elif defined(__APPLE__)
+    video2x::logger()->warn("Automatic system hibernation is not supported on macOS; skipping.");
 #else
     QDBusInterface interface("org.freedesktop.login1",
                              "/org/freedesktop/login1",


### PR DESCRIPTION
yo, I like the repo and spent some tokens to make it work on my machine, here are changes that worked for me

- CMake: ld64-compatible link flags on Apple (-dead_strip instead of -s/--gc-sections); restrict -march=native to x86-64; drop the Qt6::DBus power-management dependency on macOS; collect FFmpeg pkg-config library search dirs so -lavcodec/-lavutil resolve when FFmpeg is in a non-default prefix (Homebrew); use the .dylib suffix for the bundled libvideo2x.
- utils.cpp: compile the shutdown/sleep/hibernate helpers as no-ops on macOS (no logind/DBus), guarded by __APPLE__.

Builds against a prebuilt libvideo2x via -DUSE_EXTERNAL_VIDEO2X=ON. Requires the libvideo2x Apple Silicon support PR for k4yt3x/video2x.